### PR TITLE
delete line

### DIFF
--- a/components/directions/indoorMapSearchBar/index.js
+++ b/components/directions/indoorMapSearchBar/index.js
@@ -180,7 +180,6 @@ class IndoorMapSearchBar extends Component {
               this.setState({
                 showPredictions: false
               });
-              this.onSubmitSearchQuery();
             }}
             lightTheme
             containerStyle={containerStyle}


### PR DESCRIPTION
This line crashes the app when user presses return on a keyboard. It was calling an inexistent function.